### PR TITLE
Add 'upload_map' and 'upload_mod' to python client scope

### DIFF
--- a/apps/ory-hydra/values.yaml
+++ b/apps/ory-hydra/values.yaml
@@ -17,7 +17,7 @@ clients:
   - name: "FAF Classic Client (Python)"
     id: "95ecec08-29c1-4c48-ae0a-b000ff349cb8"
     grantType: "authorization_code,refresh_token"
-    scope: "openid,offline,lobby,public_profile"
+    scope: "openid,offline,lobby,public_profile,upload_map,upload_mod"
     redirectUri: "http://localhost,http://127.0.0.1"
     logoUri: "https://$BASE_DOMAIN/images/faf-logo.png"
     tosUri: "https://$BASE_DOMAIN/tos"

--- a/cluster/argocd/templates/secret.yaml
+++ b/cluster/argocd/templates/secret.yaml
@@ -11,8 +11,8 @@ spec:
         secretName: infisical-machine-identity
         secretNamespace: argocd
       secretsScope:
-        projectSlug: {{.Values.infisical.projectSlug}}
-        envSlug: {{.Values.infisical.envSlug}}
+        projectSlug: {{ index .Values "infisical-secret" "projectSlug" }}
+        envSlug: {{ index .Values "infisical-secret" "envSlug" }}
         secretsPath: "/argocd"
   managedSecretReference:
     secretName: dex-github


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FAF Classic Client now has permissions to upload maps and mods through OAuth authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->