### PR TITLE
Add FAF Tracker OAuth client

### DIFF
--- a/apps/ory-hydra/templates/local-secret.yaml
+++ b/apps/ory-hydra/templates/local-secret.yaml
@@ -11,4 +11,5 @@ stringData:
   FAF_QAI_SECRET: "banana"
   WIKIJS_SECRET: "banana"
   SECRETS_SYSTEM: "bananabananabananabanana"
+  FAFTRACKER_SECRET: "banana"
 {{- end}}

--- a/apps/ory-hydra/values.yaml
+++ b/apps/ory-hydra/values.yaml
@@ -137,7 +137,7 @@ clients:
       name: ory-hydra
       key: FAFTRACKER_SECRET
     grantType: "authorization_code,refresh_token"
-    scope: "openid,offline,public_profile,lobby"
+    scope: "openid,offline,public_profile"
     redirectUri: "https://faftracker.xyz/api/auth/callback"
     logoUri: "https://faftracker.xyz/favicon.svg"
     clientUri: "https://faftracker.xyz"

--- a/apps/ory-hydra/values.yaml
+++ b/apps/ory-hydra/values.yaml
@@ -130,3 +130,15 @@ clients:
     policyUri: "https://$BASE_DOMAIN/privacy"
     logoUri: "https://$BASE_DOMAIN/images/faf-logo.png"
     tokenEndpointAuthMethod: "client_secret_post"
+
+  - name: "FAF Tracker"
+    id: "8213f968-676b-4ef5-b9b7-571b60b6ca91"
+    secret:
+      name: ory-hydra
+      key: FAFTRACKER_SECRET
+    grantType: "authorization_code,refresh_token"
+    scope: "openid,offline,public_profile,lobby"
+    redirectUri: "https://faftracker.xyz/api/auth/callback"
+    logoUri: "https://faftracker.xyz/favicon.svg"
+    clientUri: "https://faftracker.xyz"
+    tokenEndpointAuthMethod: "client_secret_post"


### PR DESCRIPTION
Adds an OAuth client for FAF Tracker

Website: https://faftracker.xyz  
repo: https://github.com/Vind3ks/faftracker
Redirect URI: https://faftracker.xyz/api/auth/callback

Requested scopes:
- openid
- offline
- public_profile
~~- lobby~~

~~lobby is needed for live queue/lobby features~~

the actual oauth client secret isnt included in this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new OAuth client "FAF Tracker" to Hydra configuration, supporting authorization code and refresh token grants with required scopes, redirect URI, and client metadata.
  * Added a local secret entry to support the FAF Tracker client for local deployments and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->