### PR TITLE
Add OIDC client for fa-metrics

### DIFF
--- a/apps/ory-hydra/templates/local-secret.yaml
+++ b/apps/ory-hydra/templates/local-secret.yaml
@@ -12,4 +12,5 @@ stringData:
   WIKIJS_SECRET: "banana"
   SECRETS_SYSTEM: "bananabananabananabanana"
   FAFTRACKER_SECRET: "banana"
+  FA_METRICS_CLIENT_SECRET: "banana"
 {{- end}}

--- a/apps/ory-hydra/values.yaml
+++ b/apps/ory-hydra/values.yaml
@@ -142,3 +142,15 @@ clients:
     logoUri: "https://faftracker.xyz/favicon.svg"
     clientUri: "https://faftracker.xyz"
     tokenEndpointAuthMethod: "client_secret_post"
+
+  - name: "FA Metrics"
+    id: "20ca564b-d0d3-445f-8317-ce7cff4f878d"
+    secret:
+      name: ory-hydra
+      key: FA_METRICS_CLIENT_SECRET
+    grantType: "authorization_code,refresh_token"
+    scope: "openid,offline,public_profile"
+    redirectUri: "https://faf-auth-proxy.services.atlantishq.de/realms/atlantis/broker/faf/endpoint"
+    logoUri: "https://fa-metrics.rancher.katzencluster.atlantishq.de/favicon.svg"
+    clientUri: "https://faf-auth-proxy.services.atlantishq.de"
+    tokenEndpointAuthMethod: "client_secret_post"


### PR DESCRIPTION
Add a OIDC-Client for my Identity Broker to use for FA-Metrics.

- **Identity** Broker: https://faf-auth-proxy.services.atlantishq.de
- **Website:** https://fa-metrics.rancher.katzencluster.atlantishq.de/
- scopes: openid offline public_profile

Here is a overview of how I will use it for completeness:

<img width="891" height="421" alt="Unbenanntes Diagramm drawio" src="https://github.com/user-attachments/assets/ed94c58a-3757-42a3-a0b1-300eec717b7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced FA Metrics as a new OAuth2 client, enabling secure API integration with support for authorization code and refresh token flows, offline access capabilities, and public profile data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->