### PR TITLE
Add faf-coop-deployer Helm chart

### DIFF
--- a/apps/faf-coop-deployer/Chart.yaml
+++ b/apps/faf-coop-deployer/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: faf-coop-deployer
+version: 1.0.0
+dependencies:
+- name: infisical-secret
+  version: 1.0.0
+  repository: file://../../common/infisical-secret

--- a/apps/faf-coop-deployer/templates/config.yaml
+++ b/apps/faf-coop-deployer/templates/config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: faf-coop-deployer
+data:
+  PORT: "8080"
+  FAF_HYDRA_BASE: "https://hydra.faforever.com"
+  COOP_MAP_REPO: "https://github.com/FAForever/faf-coop-maps"
+  GIT_WORKDIR: "/tmp/coop-maps"
+  MAP_DIR: "/maps"
+  DRY_RUN: "false"

--- a/apps/faf-coop-deployer/templates/deployment.yaml
+++ b/apps/faf-coop-deployer/templates/deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: faf-coop-deployer
+  labels:
+    app: faf-coop-deployer
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: faf-coop-deployer
+  template:
+    metadata:
+      labels:
+        app: faf-coop-deployer
+    spec:
+      containers:
+        - name: faf-coop-deployer
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+          envFrom:
+            - configMapRef:
+                name: faf-coop-deployer
+            - secretRef:
+                name: faf-coop-deployer
+          resources:
+            requests:
+              memory: 128Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi
+              cpu: 500m
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 10

--- a/apps/faf-coop-deployer/templates/local-secret.yaml
+++ b/apps/faf-coop-deployer/templates/local-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.localSecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: faf-coop-deployer
+stringData:
+  DATABASE_URL: {{ .Values.localSecret.databaseUrl | quote }}
+  PATCH_VERSION: {{ .Values.localSecret.patchVersion | default "latest" | quote }}
+{{- end }}

--- a/apps/faf-coop-deployer/templates/service.yaml
+++ b/apps/faf-coop-deployer/templates/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: faf-coop-deployer
+spec:
+  selector:
+    app: faf-coop-deployer
+  ports:
+    - port: 8080
+      targetPort: 8080

--- a/apps/faf-coop-deployer/values-prod.yaml
+++ b/apps/faf-coop-deployer/values-prod.yaml
@@ -1,0 +1,1 @@
+replicaCount: 1

--- a/apps/faf-coop-deployer/values.yaml
+++ b/apps/faf-coop-deployer/values.yaml
@@ -1,0 +1,9 @@
+replicaCount: 1
+
+image:
+  repository: faforever/faf-coop-deployer
+  tag: latest
+  pullPolicy: Always
+
+infisical-secret:
+  name: faf-coop-deployer


### PR DESCRIPTION
Deploys the new `faf-coop-deployer` service which replaces the manual
`CoopMapDeployer.kt` and `CoopDeployer.kt` scripts.

Campaign team members with the `COOP_DEPLOYER` role can deploy co-op maps
and patches via REST API — no direct database or shell access required.

**Source:** https://github.com/TimMasalme/coop-deployer

**Required before merge:**
- `COOP_DEPLOYER` role merged in faf-java-api
- Infisical secret `faf-coop-deployer` created with `DATABASE_URL` and `PATCH_VERSION`
- Docker image `faforever/faf-coop-deployer` published to registry