### PR TITLE
Add FAF Tournaments OAuth client

### DIFF
--- a/apps/ory-hydra/templates/local-secret.yaml
+++ b/apps/ory-hydra/templates/local-secret.yaml
@@ -13,4 +13,5 @@ stringData:
   SECRETS_SYSTEM: "bananabananabananabanana"
   FAFTRACKER_SECRET: "banana"
   FA_METRICS_CLIENT_SECRET: "banana"
+  FAFTOURNEY_SECRET: "banana"
 {{- end}}

--- a/apps/ory-hydra/values.yaml
+++ b/apps/ory-hydra/values.yaml
@@ -154,3 +154,15 @@ clients:
     logoUri: "https://fa-metrics.rancher.katzencluster.atlantishq.de/favicon.svg"
     clientUri: "https://faf-auth-proxy.services.atlantishq.de"
     tokenEndpointAuthMethod: "client_secret_post"
+
+  - name: "FAF Tournaments"
+    id: "f4d9a7e2-1c3b-4a8e-9f26-8b5e0d47c1a9"
+    secret:
+      name: ory-hydra
+      key: FAFTOURNEY_SECRET
+    grantType: "authorization_code,refresh_token"
+    scope: "openid,offline,public_profile"
+    redirectUri: "https://tournaments.doodlepros.com/auth/faf/callback"
+    logoUri: "https://tournaments.doodlepros.com/favicon.svg"
+    clientUri: "https://tournaments.doodlepros.com"
+    tokenEndpointAuthMethod: "client_secret_post"


### PR DESCRIPTION
Adds an OAuth client for FAF Tournaments, a self-hosted tournament manager.

Website: https://tournaments.doodlepros.com
Redirect URI: https://tournaments.doodlepros.com/auth/faf/callback
Requested scopes: openid, offline, public_profile

The real client secret is not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth support for the FAF Tournaments application.
  * Configured authorization code and refresh token flows, redirect settings, scopes, and application branding.
  * Added the required tournament application secret configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->